### PR TITLE
Update control.lua

### DIFF
--- a/LargerLamps-2.0/control.lua
+++ b/LargerLamps-2.0/control.lua
@@ -8,17 +8,56 @@ local function config_refresh(event)
             local floor_recipe = game.recipe_prototypes[DLL.floor_name]
             local electric_copper_recipe = game.recipe_prototypes[DLL.electric_copper_name]
 
-            -- Check if technology is researched, then enable the recipes
+            -- Ensure technology and recipes are valid
             if technology and recipe and floor_recipe then
-                force.recipes[DLL.name].enabled = force.technologies[DLL.technology].researched
-                force.recipes[DLL.floor_name].enabled = force.technologies[DLL.technology].researched
-                log("Enabled recipes for " .. DLL.name .. " and " .. DLL.floor_name)
+                -- Check if the technology is enabled
+                if technology.enabled then
+                    -- Enable the recipes if technology is researched and visible
+                    if force.technologies[DLL.technology].researched then
+                        force.recipes[DLL.name].enabled = true
+                        force.recipes[DLL.floor_name].enabled = true
+                        log("Enabled recipes for " .. DLL.name .. " and " .. DLL.floor_name)
+                    else
+                        force.recipes[DLL.name].enabled = false
+                        force.recipes[DLL.floor_name].enabled = false
+                        log("Disabled recipes for " .. DLL.name .. " and " .. DLL.floor_name)
+                    end
+                else
+                    log("Technology " .. DLL.technology .. " is disabled")
+                end
+
+                -- Check if prerequisites are researched before enabling recipes
+                if technology.prerequisites then
+                    local prerequisites_researched = true
+                    for _, prereq in pairs(technology.prerequisites) do
+                        if not force.technologies[prereq.name].researched then
+                            prerequisites_researched = false
+                            break
+                        end
+                    end
+                    -- Enable recipes only if all prerequisites are researched
+                    if prerequisites_researched then
+                        force.recipes[DLL.name].enabled = true
+                        force.recipes[DLL.floor_name].enabled = true
+                        log("Enabled recipes after researching prerequisites")
+                    else
+                        force.recipes[DLL.name].enabled = false
+                        force.recipes[DLL.floor_name].enabled = false
+                        log("Prerequisites not yet researched")
+                    end
+                end
             end
 
             -- Enable Electric Copper Lamp Recipe when technology is researched
             if electric_copper_recipe then
-                force.recipes[DLL.electric_copper_name].enabled = force.technologies[DLL.technology].researched
-                log("Enabled recipe for " .. DLL.electric_copper_name)
+                -- Check if the technology has been researched and if it is allowed
+                if force.technologies[DLL.technology].researched then
+                    force.recipes[DLL.electric_copper_name].enabled = true
+                    log("Enabled recipe for " .. DLL.electric_copper_name)
+                else
+                    force.recipes[DLL.electric_copper_name].enabled = false
+                    log("Disabled recipe for " .. DLL.electric_copper_name)
+                end
             end
         end
     end


### PR DESCRIPTION
Posssible fix for 



The mod Larger Lamps 2.0 (0.0.8) caused a non-recoverable error.
Please report this error to the mod author.

Error while running event DeadlockLargerLamp_goakupdate::on_configuration_changed
LuaGameScript doesn't contain key technology_prototypes.
stack traceback:
[C]: in function '__index'
__DeadlockLargerLamp_goakupdate__/control.lua:6: in function <__DeadlockLargerLamp_goakupdate__/control.lua:3>

The function config_refresh in control.lua seems to contain code for Factorio 1.1 