### PR TITLE
Update recipe categories for Factorio 2.1

### DIFF
--- a/LargerLamps-2.0/changelog.txt
+++ b/LargerLamps-2.0/changelog.txt
@@ -1,4 +1,12 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.2.4
+Date: 23-06-2026
+  Bugfixes:
+    - Updated recipe prototypes for Factorio 2.1 by replacing `category` with the new `categories` table.
+    - Updated AAI Industrial recipe category overrides to use the new `categories` table.
+  Changes:
+    - Updated mod metadata for Factorio 2.1 compatibility.
+---------------------------------------------------------------------------------------------------
 Version: 0.2.3
 Date: 31-12-2025
   Bugfixes:

--- a/LargerLamps-2.0/info.json
+++ b/LargerLamps-2.0/info.json
@@ -1,13 +1,13 @@
 {
 	"name": "LargerLamps-2_0",
-	"version": "0.2.3",
-	"title": "Larger Lamps 2.0",
+	"version": "0.2.4",
+	"title": "Larger Lamps 2.1",
 	"author": "Deadlock989, Goakiller900, MasterBuilder, NullHarp",
 	"contact": "",
 	"homepage": "",
 	"dependencies": [
-		"base >= 2.0"
+		"base >= 2.1"
 	],
 	"description": "2x2 lamps that cast a wide, soft glow: an electric lamp that is signal compatible, a copper lamp that burns solid fuel, and a floor lamp panel that can be walked over.",
-	"factorio_version": "2.0"
+	"factorio_version": "2.1"
 }

--- a/LargerLamps-2.0/prototypes/mods/aai_support.lua
+++ b/LargerLamps-2.0/prototypes/mods/aai_support.lua
@@ -4,7 +4,7 @@ local DLL = require("prototypes.globals")
 if mods["aai-industry"] then
     -- Modify Large Lamp Recipe for AAI
     if data.raw["recipe"][DLL.name] then
-        data.raw["recipe"][DLL.name].category = "aai-production" -- Use AAI production category for compatibility
+        data.raw["recipe"][DLL.name].categories = { "aai-production" } -- Use AAI production category for compatibility
         data.raw["recipe"][DLL.name].ingredients = {
             { type = "item", name = "copper-plate", amount = 6 },
             { type = "item", name = "glass", amount = 4 }, -- Increased to reflect AAI's reliance on glass
@@ -15,7 +15,7 @@ if mods["aai-industry"] then
 
     -- Modify Copper Lamp Recipe for AAI
     if data.raw["recipe"][DLL.copper_name] then
-        data.raw["recipe"][DLL.copper_name].category = "aai-production"
+        data.raw["recipe"][DLL.copper_name].categories = { "aai-production" }
         data.raw["recipe"][DLL.copper_name].ingredients = {
             { type = "item", name = "copper-plate", amount = 10 }, -- Increased to emphasize copper usage
             { type = "item", name = "glass", amount = 3 },
@@ -26,7 +26,7 @@ if mods["aai-industry"] then
 
     -- Modify Electric Copper Lamp Recipe for AAI
     if data.raw["recipe"][DLL.electric_copper_name] then
-        data.raw["recipe"][DLL.electric_copper_name].category = "aai-production"
+        data.raw["recipe"][DLL.electric_copper_name].categories = { "aai-production" }
         data.raw["recipe"][DLL.electric_copper_name].ingredients = {
             { type = "item", name = "copper-plate", amount = 12 },
             { type = "item", name = "glass", amount = 6 },
@@ -38,7 +38,7 @@ if mods["aai-industry"] then
 
     -- Modify Floor Lamp Recipe for AAI
     if data.raw["recipe"][DLL.floor_name] then
-        data.raw["recipe"][DLL.floor_name].category = "aai-production"
+        data.raw["recipe"][DLL.floor_name].categories = { "aai-production" }
         data.raw["recipe"][DLL.floor_name].ingredients = {
             { type = "item", name = "electronic-circuit", amount = 2 },
             { type = "item", name = "copper-cable", amount = 8 },
@@ -55,16 +55,16 @@ if mods["aai-industry"] then
 else
     -- Fallback for vanilla compatibility
     if data.raw["recipe"][DLL.name] then
-        data.raw["recipe"][DLL.name].category = "basic-crafting"
+        data.raw["recipe"][DLL.name].categories = { "basic-crafting" }
     end
     if data.raw["recipe"][DLL.copper_name] then
-        data.raw["recipe"][DLL.copper_name].category = "basic-crafting"
+        data.raw["recipe"][DLL.copper_name].categories = { "basic-crafting" }
     end
     if data.raw["recipe"][DLL.electric_copper_name] then
-        data.raw["recipe"][DLL.electric_copper_name].category = "basic-crafting"
+        data.raw["recipe"][DLL.electric_copper_name].categories = { "basic-crafting" }
     end
     if data.raw["recipe"][DLL.floor_name] then
-        data.raw["recipe"][DLL.floor_name].category = "basic-crafting"
+        data.raw["recipe"][DLL.floor_name].categories = { "basic-crafting" }
     end
 end
 

--- a/LargerLamps-2.0/prototypes/recipes/copper_lamp_recipe.lua
+++ b/LargerLamps-2.0/prototypes/recipes/copper_lamp_recipe.lua
@@ -14,7 +14,7 @@ data:extend({
         },
         subgroup = "circuit-network",  -- Copper lamp under circuit-network
         order = "a[lamp]-b[copper-lamp]",  -- Place after large lamp
-        category = "crafting"  -- Category for crafting
+        categories = { "crafting" }  -- Categories for crafting
     },
     -- Define the hidden burning recipe for the copper lamp
     {
@@ -26,7 +26,7 @@ data:extend({
         icon = string.format("%s/copper-lamp.png", DLL.icon_path),  -- Icon path for the recipe
         icon_size = 64,
         icon_mipmaps = 4,
-        category = "lamp-burning",  -- Custom category for lamp burning
+        categories = { "lamp-burning" },  -- Custom category for lamp burning
         ingredients = {},
         results = {},
         subgroup = "other",  -- Optional: Adjust this if needed

--- a/LargerLamps-2.0/prototypes/recipes/electric_copper_lamp_recipe.lua
+++ b/LargerLamps-2.0/prototypes/recipes/electric_copper_lamp_recipe.lua
@@ -15,6 +15,6 @@ data:extend({
         },
         subgroup = "circuit-network",  -- Electric copper lamp under circuit-network
         order = "a[lamp]-c[electric-copper-lamp]",  -- Place after copper lamp
-        category = "crafting"  -- Category for crafting
+        categories = { "crafting" }  -- Categories for crafting
     }
 })

--- a/LargerLamps-2.0/prototypes/recipes/floor_lamp_recipe.lua
+++ b/LargerLamps-2.0/prototypes/recipes/floor_lamp_recipe.lua
@@ -15,6 +15,6 @@ data:extend({
         },
         subgroup = "circuit-network",  -- Floor lamp under circuit-network
         order = "a[lamp]-d[floor-lamp]",  -- Place after electric copper lamp
-        category = "crafting"  -- Category for crafting
+        categories = { "crafting" }  -- Categories for crafting
     }
 })

--- a/LargerLamps-2.0/prototypes/recipes/large_lamp_recipe.lua
+++ b/LargerLamps-2.0/prototypes/recipes/large_lamp_recipe.lua
@@ -15,6 +15,6 @@ data:extend({
         },
         subgroup = "circuit-network",  -- All lamps under circuit-network
         order = "a[lamp]-a[large-lamp]",  -- Place it first in the list
-        category = "crafting"  -- Category for crafting
+        categories = { "crafting" }  -- Categories for crafting
     }
 })


### PR DESCRIPTION
## What changed

- Replaced recipe prototype `category = ...` fields with `categories = { ... }` for Factorio 2.1.
- Updated the hidden copper lamp burning recipe to use the new `categories` table.
- Updated AAI Industrial recipe category overrides from `.category` to `.categories`.
- Bumped mod metadata to version `0.2.4` and Factorio `2.1`.
- Added a changelog entry for the 2.1 compatibility fix.

## Why

Factorio 2.1 now rejects recipe prototypes using the old `category` field with the loader error:

> In RecipePrototype, `category` and `additional_categories` got merged into `categories` table. Please use that instead.