### PR TITLE
[codex] Release 0.2.6: fix electric copper lamp research gating

### DIFF
--- a/LargerLamps-2.0/changelog.txt
+++ b/LargerLamps-2.0/changelog.txt
@@ -1,4 +1,14 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.2.6
+Date: 23-06-2026
+  Bugfixes:
+    - Fixed Electric Copper Lamp being craftable before lighting research.
+    - Replaced the Electric Copper Lamp recipe's advanced circuits with electronic circuits so the recipe fits the lighting research tier.
+  Notes:
+    - Fix based on the report and suggestion by odnols.
+    - Update prepared with ChatGPT/Codex assistance because I was too lazy to do the manual cleanup myself.
+    - Thanks to the other authors and contributors for the fixes, ideas, and continued improvements.
+---------------------------------------------------------------------------------------------------
 Version: 0.2.5
 Date: 23-06-2026
   Changes:

--- a/LargerLamps-2.0/info.json
+++ b/LargerLamps-2.0/info.json
@@ -1,7 +1,6 @@
 {
 	"name": "LargerLamps-2_0",
-	"version": "0.2.5",
-	"version": "0.2.4",
+	"version": "0.2.6",
 	"title": "Larger Lamps 2.1",
 	"author": "Deadlock989, Goakiller900, MasterBuilder, NullHarp",
 	"contact": "",

--- a/LargerLamps-2.0/prototypes/recipes/electric_copper_lamp_recipe.lua
+++ b/LargerLamps-2.0/prototypes/recipes/electric_copper_lamp_recipe.lua
@@ -4,9 +4,9 @@ data:extend({
     {
         name = DLL.electric_copper_name,
         type = "recipe",
-        enabled = true,
+        enabled = false,
         ingredients = {
-            { type = "item", name = "advanced-circuit", amount = 2 },
+            { type = "item", name = "electronic-circuit", amount = 2 },
             { type = "item", name = "copper-cable", amount = 4 },
             { type = "item", name = "iron-plate", amount = 6 },
         },


### PR DESCRIPTION
## What changed

- Bumped the mod to version `0.2.6`.
- Changed the Electric Copper Lamp recipe from `enabled = true` to `enabled = false`, so it is actually gated behind lighting research.
- Replaced the advanced circuit ingredient with electronic circuits so the recipe fits the early lighting research tier.
- Added a `0.2.6` changelog entry.

## Why

Fixes #29.

The Electric Copper Lamp was available from the start even though it is also unlocked by lighting research, making the research unlock pointless. The issue also suggested replacing the advanced circuit with a green circuit, which matches the lighting research stage better.

## Notes

- Fix based on the report and suggestion by @odnols.
- Update prepared with ChatGPT/Codex assistance because I was too lazy to do the manual cleanup myself.
- Thanks to the other authors and contributors for the fixes, ideas, and continued improvements.

## Testing

Manually tested locally by editing the mod folder directly and confirming that the recipe changed in-game after removing the duplicate ZIP/folder load issue.